### PR TITLE
Update AnimeBytes IRC server

### DIFF
--- a/AutodlIrssi/trackers/AnimeBytes.tracker
+++ b/AutodlIrssi/trackers/AnimeBytes.tracker
@@ -38,7 +38,7 @@
 	<servers>
 		<server
 			network="AnimeBytes"
-			serverNames="mei.animebyt.es"
+			serverNames="irc.animebytes.tv"
 			channelNames="#announce"
 			announcerNames="Satsuki"
 		/>


### PR DESCRIPTION
AnimeBytes' IRC server is at `irc.animebytes.tv` now. The `animebyt.es` domain is deprecated.
