### PR TITLE
Update SslSocket.pm

### DIFF
--- a/AutodlIrssi/SslSocket.pm
+++ b/AutodlIrssi/SslSocket.pm
@@ -84,6 +84,9 @@ sub connect {
 
 		$self->{ssl} = Net::SSLeay::new($AutodlIrssi::g->{ssl_ctx}) or die "Could not create SSL\n";
 		Net::SSLeay::set_fd($self->{ssl}, fileno($self->{socket}));
+		if ($hostname =~ /[[:alpha:]]/) {
+			Net::SSLeay::set_tlsext_host_name($self->{ssl}, $hostname);
+		}
 		Net::SSLeay::set_connect_state($self->{ssl});
 
 		$self->_startConnect($hostname, $port);

--- a/AutodlIrssi/SslSocket.pm
+++ b/AutodlIrssi/SslSocket.pm
@@ -84,10 +84,8 @@ sub connect {
 
 		$self->{ssl} = Net::SSLeay::new($AutodlIrssi::g->{ssl_ctx}) or die "Could not create SSL\n";
 		Net::SSLeay::set_fd($self->{ssl}, fileno($self->{socket}));
-		if ($hostname =~ /[[:alpha:]]/) {
-			Net::SSLeay::set_tlsext_host_name($self->{ssl}, $hostname);
-		}
 		Net::SSLeay::set_connect_state($self->{ssl});
+		Net::SSLeay::set_tlsext_host_name($self->{ssl}, $hostname);
 
 		$self->_startConnect($hostname, $port);
 		$self->_installHandshakeHandler(0, $callback);


### PR DESCRIPTION
This fixes problem connecting to SSL sites that uses SNI.
Regex is used to check if $hostname is numeric IP or host name (if contains any letter) in this case we call set_tlsext_host_name. This should probably be done differently.