### PR TITLE
A working method to set the Irrsi/Gui IP in the autodl.cfg

### DIFF
--- a/AutodlIrssi/AutodlConfigFileParser.pm
+++ b/AutodlIrssi/AutodlConfigFileParser.pm
@@ -69,6 +69,7 @@ sub defaultOptions {
 		memoryLeakCheck => 0,
 		guiServerPort => 0,
 		guiServerPassword => '',
+		guiServerIp => '127.0.0.1',
 		uniqueTorrentNames => 0,
 
 		webui => {
@@ -444,6 +445,7 @@ sub doHeaderOptions {
 		'memory-leak-check' => 'memoryLeakCheck',
 		'gui-server-port' => 'guiServerPort',
 		'gui-server-password' => 'guiServerPassword',
+		'gui-server-ip' => 'guiServerIp',
 		'unique-torrent-names' => 'uniqueTorrentNames',
 	});
 

--- a/AutodlIrssi/GuiServer.pm
+++ b/AutodlIrssi/GuiServer.pm
@@ -189,7 +189,6 @@ use File::Basename;
 use File::Spec;
 
 # The address we listen for connections. Default is 127.0.0.1
-use constant LISTEN_ADDRESS => '127.0.0.1';
 
 sub new {
 	my ($class, $autodlCmd) = @_;
@@ -218,7 +217,7 @@ sub setListenPort {
 		$port = 0 if $port < 0 || $port > 0xFFFF;
 		return if $self->{port} == $port;
 
-		my $address = LISTEN_ADDRESS;
+		my $address = $AutodlIrssi::g->{options}{guiServerIp};
 		$self->{serverSocket}->setAddress($address, $port);
 		$self->{port} = $port;
 

--- a/AutodlIrssi/MatchedRelease.pm
+++ b/AutodlIrssi/MatchedRelease.pm
@@ -618,7 +618,7 @@ sub _getRtAddress {
 		}
 	}
 
-	$rtAddress = "127.0.0.1$rtAddress" if $rtAddress =~ /^:\d{1,5}$/;
+	$rtAddress = "$AutodlIrssi::g->{options}{guiServerIp}$rtAddress" if $rtAddress =~ /^:\d{1,5}$/;
 
 	return $rtAddress if isInternetAddress($rtAddress);
 	return getAbsPath($rtAddress);
@@ -674,7 +674,7 @@ sub _sendRtorrent {
 		createDirectories($rtDir) if $rtDir ne "";
 
 		# Set REMOTE_ADDR since there could be user commands
-		my $scgi = new AutodlIrssi::Scgi($rtAddress, {REMOTE_ADDR => "127.0.0.1"});
+		my $scgi = new AutodlIrssi::Scgi($rtAddress, {REMOTE_ADDR => $AutodlIrssi::g->{options}{guiServerIp}});
 		my $xmlrpc = new AutodlIrssi::XmlRpcSimpleCall($scgi);
 		$xmlrpc->method($rtPriority eq '0' ? 'load.normal' : 'load.start');
 		$xmlrpc->string($filename);

--- a/AutodlIrssi/Startup.pm
+++ b/AutodlIrssi/Startup.pm
@@ -356,6 +356,7 @@ sub reloadAutodlConfigFile {
 				my $options = $configFileParser->getOptions();
 				$AutodlIrssi::g->{options}{guiServerPort} = $options->{guiServerPort} if $options->{guiServerPort} != 0;
 				$AutodlIrssi::g->{options}{guiServerPassword} = $options->{guiServerPassword} if $options->{guiServerPassword} ne "";
+				$AutodlIrssi::g->{options}{guiServerIp} = $options->{guiServerIp} if $options->{guiServerIp} ne "";
 				$AutodlIrssi::g->{options}{rtAddress} = $options->{rtAddress} if $options->{rtAddress} ne "";
 			}
 		}


### PR DESCRIPTION
This is to support custom networking environments that deviate from the vanilla OS practices and are not currently supported.

To do this a new configuration option has been created that allows setting the IP in the autodl.cfg:

gui-server-ip = 10.0.0.1

When this setting is empty the default value is 127.0.0.1 as per the expected defaults.

This prevents compromising the default installation practice whilst providing extended and easy to document functionality.

**Please read the contributing guidelines linked above before opening a pull request.**
