### PR TITLE
Fix for the issue "Torrent size as hard filtering criteria #201"

### DIFF
--- a/AutodlIrssi/FilterManager.pm
+++ b/AutodlIrssi/FilterManager.pm
@@ -169,6 +169,11 @@ sub checkFilter {
 		return 0 if defined $numDownloads && $numDownloads >= $filter->{maxDownloads};
 	}
 
+	# Check filter size
+	# This is a soft check when torrentSizeInBytes is not defined,
+	# condition will be treated as satisfied
+	return checkFilterSize($ti->{torrentSizeInBytes}, $filter);
+
 	return 1;
 }
 

--- a/AutodlIrssi/IrcHandler.pm
+++ b/AutodlIrssi/IrcHandler.pm
@@ -125,7 +125,8 @@ sub onNewIrcLine {
 	my $ti = $self->handleNewAnnouncerLine($line, $networkName, $serverName, $channelName, $userName);
 	return 0 unless defined $ti;
 
-	my $matchedRelease = new AutodlIrssi::MatchedRelease($self->{downloadHistory});
+	# Matched Release takes filterManager as argument, so that it can check filters during 2nd attempt
+	my $matchedRelease = new AutodlIrssi::MatchedRelease($self->{downloadHistory}, $self->{filterManager});
 	$matchedRelease->start($ti);
 	return 1;
 }


### PR DESCRIPTION
This is quick workaround for the issue "Torrent size as hard filtering criteria #201"
https://github.com/autodl-community/autodl-irssi/issues/201#issue-655679838

The fix is designed to bring minimum changes to the flow and as well as to achieve the end result
Two major changes
1. Filter manager performs a soft check on torrent size. When "torrentSizeInBytes" is not defined, treats the condition as satisfied, if defined checks the condition.
2. MatchedRelease when size condition is not met instead of aborting the process triggers the filter check and download process again with additional information of "torrentSizeInBytes"

Short comings of the fix
1. Under certain conditions torrent file is downloaded twice. 2nd download of torrent file certainly leads to an action.
2. Time and computation wasted in rechecking the filter

Possible improvements
1. Avoid downloading torrent file again, if it is available in temp
2. Parse torrentSizeInBytes from IRC announcement wherever possible

**Please read the contributing guidelines linked above before opening a pull request.**
