### PR TITLE
Fix multiple matching filters with different sizes

### DIFF
--- a/AutodlIrssi/FilterManager.pm
+++ b/AutodlIrssi/FilterManager.pm
@@ -168,8 +168,10 @@ sub checkFilter {
 		}
 		return 0 if defined $numDownloads && $numDownloads >= $filter->{maxDownloads};
 	}
-
-	return 1;
+	# If the torrent hasn't been downlaoded yet from the tracker, torrentSizeInBytes
+	# won't be defined, but this function may be re-called after the torrent is downloaded,
+	# and at that point we can determine whether this filter matches based upon size
+	return checkFilterSize($ti->{torrentSizeInBytes}, $filter);
 }
 
 sub checkFilterRegex {

--- a/AutodlIrssi/MatchedRelease.pm
+++ b/AutodlIrssi/MatchedRelease.pm
@@ -295,9 +295,13 @@ sub _onTorrentDownloaded {
 
 	if (!AutodlIrssi::FilterManager::checkFilterSize($self->{ti}{torrentSizeInBytes}, $self->{ti}{filter})) {
 		$self->{ti}{filter}{state}->restoreDownloadCount($self->{filterDlState});
-		return;
+		# we may have used the wrong filter since we didn't know the torrent size until now. See if
+		# there is a matching filter now that we know the size
+		$self->{ti}{filter} = $AutodlIrssi::g->{filterManager}->findFilter($self->{ti});
+		return unless defined $self->{ti}{filter};
+		$self->{filterDlState} = $self->{ti}{filter}{state}->incrementDownloads();
 	}
-	else {
+	{
 		$self->_addDownload();
 
 		message(3, "Matched " . $self->_getTorrentInfoString());


### PR DESCRIPTION
When two or more filters have different size ranges but both match an announcement, if the filter with the non-matching size is evaluated first, the announcement will fail to match. It will never be evaluated against any subsequent matches which might have an acceptable size.

This change will cause the filters to be re-evaluated after the torrent has been download in the case that the size fails to match.

Fixes #201 

I didn't see #202 when I made this, but this is an alternative approach which only needs to download the torrent once.